### PR TITLE
Fix bug in pre-population of member fields when editing a group

### DIFF
--- a/client/editGroup.jsx
+++ b/client/editGroup.jsx
@@ -9,13 +9,15 @@ class EditGroup extends React.Component {
   // component will fetch group data before mounting
   componentWillMount() {
     this.getGroup((members) => {
+      console.log(members)
+
       for (var i = 0; i < members.length; i++) {
         this.setState({
           memberForms: this.state.memberForms.concat(( 
             <EditMember
               name={members[i].name}
-              instagram={members[i].instagram[0].groupMemberName}
-              twitter={members[i].twitter[0].groupMemberName}
+              instagram={members[i].instagramHandle}
+              twitter={members[i].twitterHandle}
             />
           ))
         });

--- a/client/group.jsx
+++ b/client/group.jsx
@@ -29,7 +29,7 @@ class Group extends React.Component {
 	render() {
 		return (
 	  <div className='group'>
-	    <span className='group-name' onClick={() => this.props.clickHandler(this.props.name)}>{this.props.name}</span>
+	    <span><a href='#' className='group-name' onClick={() => this.props.clickHandler(this.props.name)}>{this.props.name}</a></span>
 	    <a href='#' className='group-edit' onClick={this.handleEditClick.bind(this)}>Edit...</a>
 	    {this.state.editGroupForm}
 	  </div>

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -29,6 +29,8 @@ module.exports = {
             var memberObj = {};
             var groupMemberName = groupMemberAccountInformation[index].name
             memberObj.name = groupMemberName;
+            memberObj.instagramHandle = groupMemberAccountInformation[index].instagram;
+            memberObj.twitterHandle = groupMemberAccountInformation[index].twitter;
 
             // call to instagram
             Parse.parseInstagramHTML(groupMemberAccountInformation[index].instagram, groupMemberName, function(instagramData) {


### PR DESCRIPTION
Added the saved twitter and instagram handles as properties of the response object from the server. This is what will be used to pre-populate the form during a group edit.

Also changed the group names to be an anchor so that the user knows they're clickable and makes it more intuitive that that's how you change the feed to a certain group.
