### PR TITLE
Fix bug for displaying feed if the group name is changed

### DIFF
--- a/client/app.jsx
+++ b/client/app.jsx
@@ -140,7 +140,7 @@ class App extends React.Component {
           <Header login={this.setCurrentUser.bind(this)} logout={this.logout.bind(this)}/>
         </div>
         <div className='app-sidebar'>
-          <Sidebar addToGroups={this.addToGroups.bind(this)} currentUser={this.state.currentUser} getGroups={this.getGroups.bind(this)} groups={this.state.groups} groupClickHandler={this.setCurrentGroup.bind(this)} />
+          <Sidebar addToGroups={this.addToGroups.bind(this)} currentUser={this.state.currentUser} getGroups={this.getGroups.bind(this)} groups={this.state.groups} setCurrentGroup={this.setCurrentGroup.bind(this)} currentGroup={this.state.currentGroup} />
         </div>
         <div className='app-feed'>
           <Feed group={this.state.currentGroup} posts={this.state.posts} />

--- a/client/editGroup.jsx
+++ b/client/editGroup.jsx
@@ -115,8 +115,17 @@ class EditGroup extends React.Component {
 
 		this.sendChanges(newGroupName, members);
     
+    // setting the current group updates the feed--
+    // this updates the feed if the group being edited is currently
+    // the group being displayed
+    if (this.props.currentGroup === this.props.currentGroupName) {
+      this.props.setCurrentGroup(newGroupName);
+    }
+    
+    // fetches groups with changes for sidebar
     this.props.getGroups();
 
+    // closes the edit form
   	this.props.handleEditClick(e);
   }
 

--- a/client/group.jsx
+++ b/client/group.jsx
@@ -14,7 +14,7 @@ class Group extends React.Component {
 		// we know a form should be generated after the click so we set the new state
 		if (!this.state.editGroupClicked) {
 			this.setState({
-				editGroupForm: <EditGroup getGroups={this.props.getGroups} currentUser={this.props.currentUser} currentGroupName={this.props.name} handleEditClick={this.handleEditClick.bind(this)}/>,
+				editGroupForm: <EditGroup getGroups={this.props.getGroups} currentUser={this.props.currentUser} setCurrentGroup={this.props.setCurrentGroup} currentGroupName={this.props.name} currentGroup={this.props.currentGroup} handleEditClick={this.handleEditClick.bind(this)}/>,
 				editGroupClicked: true
 			})
 		} else {
@@ -29,7 +29,7 @@ class Group extends React.Component {
 	render() {
 		return (
 	  <div className='group'>
-	    <span><a href='#' className='group-name' onClick={() => this.props.clickHandler(this.props.name)}>{this.props.name}</a></span>
+	    <span><a href='#' className='group-name' onClick={() => this.props.setCurrentGroup(this.props.name)}>{this.props.name}</a></span>
 	    <a href='#' className='group-edit' onClick={this.handleEditClick.bind(this)}>Edit...</a>
 	    {this.state.editGroupForm}
 	  </div>

--- a/client/sidebar.jsx
+++ b/client/sidebar.jsx
@@ -19,7 +19,7 @@ class Sidebar extends React.Component {
   
         <div className='sidebar-groups-header'>Your groups:</div>
         <div className='sidebar-groups'>
-          {this.props.groups.map(groupName => <Group getGroups={this.props.getGroups} currentUser={this.props.currentUser} name={groupName} clickHandler={this.props.groupClickHandler} />)}
+          {this.props.groups.map(groupName => <Group getGroups={this.props.getGroups} currentUser={this.props.currentUser} currentGroup={this.props.currentGroup} name={groupName} setCurrentGroup={this.props.setCurrentGroup} />)}
         </div>
       </div>
     );


### PR DESCRIPTION
Before, if the current feed being displayed is for the group
that is being edited, and the group name gets changed,
the feed disappears and the group name in the feed doesn't get
updated.

This fixes that bug.
